### PR TITLE
Added back the removed 'setDeliveryDate'

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1614,6 +1614,7 @@ final class Gateway extends \WC_Payment_Gateway
 
         $item->setVatPercentage( $tax_rate )
             ->setProductCode( $this->get_item_product_code( $order_item ) )
+            ->setDeliveryDate( apply_filters( 'paytrail_delivery_date', date( 'Y-m-d' ) ) )
             ->setDescription( $this->get_item_description( $order_item ) )
             ->setStamp( (string) $order_item->get_id() );
 


### PR DESCRIPTION
the 'setDeliverydate' has to be set back since it is a required information in the SDK