### PR TITLE
added a missing escape

### DIFF
--- a/src/View/ProviderForm.php
+++ b/src/View/ProviderForm.php
@@ -59,7 +59,7 @@ EOL;
         
     }
     echo '</style>';
-    echo '<div class="paytrail-provider-group-title ' . $group['id']  . '">';
+    echo '<div class="paytrail-provider-group-title ' . esc_attr($group['id'])  . '">';
     echo '<i></i>';
     echo esc_html( $group['name'] );
     echo '</div>';


### PR DESCRIPTION
Added a missing escape that was pointed out in the WP org information email.
