### PR TITLE
Make it possible to tweak paytrail order items via apply_filters

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1193,7 +1193,7 @@ final class Gateway extends \WC_Payment_Gateway
     private function get_order_items($order)
     {
         // Get the items from the order
-        $order_items = $order->get_items( [ 'line_item', 'fee', 'shipping' ] );
+        $order_items = apply_filters('woocommerce_paytrail_gateway_get_order_items',$order->get_items( [ 'line_item', 'fee', 'shipping' ] ),$order);
         $order_total = $this->helper->handle_currency( $order->get_total() );
 
         // Convert items to SDK Item objects.


### PR DESCRIPTION
## Related tickets & documents

## Description

It is currently not possible to apply fixes to sent Paytrail "items" on payment creation in a situation where our store has **negative fees**. Paytrail API doesn't allow negatively priced "items" and plugin doesn't wrap anything with `apply_filters`. This PR enables custom tweaks to list of Woocommerce items before they are processed as Paytrail items.

What will get wrapped with `apply_filters` (src/Gateway.php line 1196):

```php
/**
     * @param WC_Order|\WC_Subscription $order
     * @return array
     * @throws \Exception
     */
    private function get_order_items($order)
    {
        // Get the items from the order
        $order_items = apply_filters('woocommerce_paytrail_gateway_get_order_items',$order->get_items( [ 'line_item', 'fee', 'shipping' ] ),$order);
        $order_total = $this->helper->handle_currency( $order->get_total() );
```

A snippet of mu-plugin merging negative fees to singular line-items with said filter:
```php
<?php
/**
 * @wordpress-plugin
 * Plugin Name:       [09] Make paytrail compatible with negative fees
 * Plugin URI:        https://agendahelsinki.fi
 * Description:       Custom, blueprinted UI for order management
 * Version:           1.0.0
 * Requires at least: 5.5
 * Requires PHP:      7.4
 * Author:            agendah
 * Author URI:        https://agendahelsinki.fi
 * Domain Path:       /languages
 * License:           GPL v3 or later
 * License URI:       https://www.gnu.org/licenses/gpl-3.0.txt
 */
add_filter('woocommerce_paytrail_gateway_get_order_items',function($items,$order){
  /** @var WC_Order */
  $order = $order;

  /** @var WC_Order_Item_Product[] */
  $order_items = $order->get_items(['line_item']);

  /** @var WC_Order_Item_Fee[] */
  $fees = $order->get_items(['fee']);
  
  if(!empty($order_items)){
    foreach($order_items as $line_item){
      /** Set negative fee to first line item and remove fee */
      if(!empty($fees)&&!is_bool($line_item)){
        foreach($fees as $fee){
          if(floatval($fee->get_amount())<0){
            $total = floatval($line_item->get_total());
            $newtotal = $total - abs(floatval($fee->get_amount()));
            $total_tax = $newtotal * 0.24;
            $line_item->set_total($newtotal);
            $line_item->set_total_tax($total_tax);
          }
        }
      }
    }
  }
  return $order_items;
},100,2);
?>
```