### PR TITLE
Checkout page login text tweak

### DIFF
--- a/src/View/ProviderForm.php
+++ b/src/View/ProviderForm.php
@@ -87,7 +87,7 @@ EOL;
     }
     if  (is_user_logged_in() && $group['id'] == 'creditcard') {
         (new \Paytrail\WooCommercePaymentGateway\Gateway)->render_saved_payment_methods();
-    } elseif (get_option( 'users_can_register' ) == 1){
+    } elseif (get_option( 'users_can_register' ) == 1 && $group['id'] == 'creditcard'){
         $mypage_link = get_permalink( wc_get_page_id( 'myaccount' ) );
         echo '<p class="add-card-login-description">';
         echo sprintf(__('You can save your card details for next time by <a href="%s">logging in to the store or by creating an account.</a>'), $mypage_link);


### PR DESCRIPTION
Removes the login text from all other payment methods than credit cards.
