### PR TITLE
Fixed possible race condition between redirect and callback payment processing

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -623,6 +623,12 @@ final class Gateway extends \WC_Payment_Gateway
 
                 $transaction_id = filter_input( INPUT_GET, 'checkout-transaction-id' );
 
+                // If this transaction has already been processed, don't process again
+                if( $order->get_transaction_id() === $transaction_id ) {
+                    $this->log('Paytrail: handle_payment_response, transaction id '.$transaction_id.' already processed for order '.$order->get_id(), 'debug');
+                    return false;
+                }
+
                 // Save transient to avoid race condition between redirect and callback processing
                 \set_transient( 'checkout_transaction_id_processing_'.$transaction_id, "yes", 60 );
 


### PR DESCRIPTION
## The problem
Sometimes payments were processed twice, indicated by two "Payment completed" order notes. This also triggered the `payment_complete` action twice, resulting in duplicate order confirmation emails. Furthermore, if other plugins were hooked into this action, their actions were also triggered twice, causing problems.

## How to replicate the problem
Add the following code snippet and make a test order using Paytrail:

```php
add_action( 'woocommerce_pre_payment_complete', function() {
    sleep( 10 ); // sleep to simulate a slow running third party plugin
} );
```

This will cause two "Payment completed" order notes and two order confirmation emails. Make sure you are in an environment that is able to receive callbacks from Paytrail.

## The cause
In `Gateway::handle_payment_response` the check for avoiding duplicate payment processing is done with the `validate_order_payment_processing` function, which checks if the status of the order is `processing` or `completed`. If the status is either of these, the payment will not be processed again. However, other plugins may be hooked into `woocommerce_pre_payment_complete` to run some action, like generating a PDF receipt of the payment to be attached to the order confirmation email. This may take some time and the order is still in the `pending` status while this hook is running. Therefore the callback from Paytrail may come during this time, triggering the `payment_complete` hook twice.

## The solution
Added a transient when the payment processing starts and modified `validate_order_payment_processing` to check if this transient exists, and to try again after 15 seconds if that is the case. Also added a condition to check if the same transaction ID has already been set to an order, and not processing the transaction again if that is the case.

This might also solve Issue #76 without the need for a random delay in the callback