### PR TITLE
Fix rounding row negative amount

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1251,7 +1251,7 @@ final class Gateway extends \WC_Payment_Gateway {
 			return ( $item->getUnitPrice() * $item->getUnits() );
 		}, $items)));
 
-		$diff = abs($sub_sum - $order_total);
+		$diff = $order_total - $sub_sum;
 		if ($diff > 0) {
 			$rounding_item = new Item();
 			$rounding_item->setDescription(__('Rounding', 'paytrail-for-woocommerce'));
@@ -1261,6 +1261,12 @@ final class Gateway extends \WC_Payment_Gateway {
 			$rounding_item->setProductCode('rounding-row');
 
 			$items[] = $rounding_item;
+		} elseif ($diff < 0) {
+			// Add rounding error to last item price if sub sum is too high.
+			$lastItemKey = array_key_last($items);
+			$lastItem = $items[$lastItemKey];
+			$lastItem->setUnitPrice($lastItem->getUnitPrice() -1);
+			$items[$lastItemKey] = $lastItem;
 		}
 
 		return $items;

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -471,12 +471,25 @@ final class Gateway extends \WC_Payment_Gateway {
 
 		$html .= '</ul>';
 
+		$kses_arr = [
+			'li' => ['class' => []],
+			'label' => ['for' => []],
+			'input' => [
+				'id' => [],
+				'type' => [],
+				'name' => [],
+				'class' => []
+			],
+			'div' => ['class' => []],
+			'ul' => ['class' => []]
+		];
+
 		/**
 		 * Show payment methods
 		 *
 		 * @since 1.0
 		 */
-		echo wp_kses_post(apply_filters('wc_payment_gateway_form_saved_payment_methods_html', $html, $this));
+		echo wp_kses(apply_filters('wc_payment_gateway_form_saved_payment_methods_html', $html, $this), $kses_arr);
 	}
 
 	/**

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1262,14 +1262,27 @@ final class Gateway extends \WC_Payment_Gateway {
 
 			$items[] = $rounding_item;
 		} elseif ($diff < 0) {
-			// Add rounding error to last item price if sub sum is too high.
-			$lastItemKey = array_key_last($items);
+			// Add rounding error to last not zero price item if sub sum is too high.
+			$lastItemKey = $this->getLastNonZeroItem($items, $diff);
 			$lastItem = $items[$lastItemKey];
-			$lastItem->setUnitPrice($lastItem->getUnitPrice() -1);
+			$lastItem->setUnitPrice($lastItem->getUnitPrice() - $diff);
 			$items[$lastItemKey] = $lastItem;
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Loop items from back and find first (last) non zero item to subtract difference.
+	 */
+	private function getLastNonZeroItem( $items, $diff ) {
+		$reversedItems = array_reverse($items);
+		foreach ($reversedItems as $key => $item) {
+			if (( $item->getUnitPrice() - $diff ) > 0) {
+				// Return on first non zero item
+				return $key;
+			}
+		}
 	}
 
 	/**

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1263,7 +1263,7 @@ final class Gateway extends \WC_Payment_Gateway {
 			$items[] = $rounding_item;
 		} elseif ($diff < 0) {
 			// Add rounding error to last not zero price item if sub sum is too high.
-			$lastItemKey = $this->getLastNonZeroItem($items, $diff);
+			$lastItemKey = $this->getLastNonZeroItemKey($items, $diff);
 			$lastItem = $items[$lastItemKey];
 			$lastItem->setUnitPrice($lastItem->getUnitPrice() - $diff);
 			$items[$lastItemKey] = $lastItem;
@@ -1275,7 +1275,7 @@ final class Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Loop items from back and find first (last) non zero item to subtract difference.
 	 */
-	private function getLastNonZeroItem( $items, $diff ) {
+	private function getLastNonZeroItemKey( $items, $diff ) {
 		$reversedItems = array_reverse($items);
 		foreach ($reversedItems as $key => $item) {
 			if (( $item->getUnitPrice() - $diff ) > 0) {

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -1251,13 +1251,12 @@ final class Gateway extends \WC_Payment_Gateway {
 			return ( $item->getUnitPrice() * $item->getUnits() );
 		}, $items)));
 
-		if ($sub_sum != $order_total) {
-			$diff = absint($sub_sum - $order_total);
-
+		$diff = abs($sub_sum - $order_total);
+		if ($diff > 0) {
 			$rounding_item = new Item();
 			$rounding_item->setDescription(__('Rounding', 'paytrail-for-woocommerce'));
 			$rounding_item->setVatPercentage(0);
-			$rounding_item->setUnits(( $order_total - $sub_sum > 0 ) ? 1 : -1);
+			$rounding_item->setUnits(1);
 			$rounding_item->setUnitPrice($diff);
 			$rounding_item->setProductCode('rounding-row');
 

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -476,7 +476,7 @@ final class Gateway extends \WC_Payment_Gateway {
 		 *
 		 * @since 1.0
 		 */
-		echo esc_html(apply_filters('wc_payment_gateway_form_saved_payment_methods_html', $html, $this)); // @codingStandardsIgnoreLine
+		echo wp_kses_post(apply_filters('wc_payment_gateway_form_saved_payment_methods_html', $html, $this));
 	}
 
 	/**

--- a/src/View/ProviderForm.php
+++ b/src/View/ProviderForm.php
@@ -46,22 +46,18 @@ array_walk($data['groups'], function ( $group) {
 		// Styles for group icons
 		$group_id =  $group['id'];
 		$group_icon = $group['icon'];
-		if (0 === $key) {
-
-			echo esc_html(
-			<<<EOL
-			.payment_method_paytrail .paytrail-provider-group-title.$group_id i {
-				background: url($group_icon) no-repeat;
+		if (0 === $key) { ?>
+			.payment_method_paytrail .paytrail-provider-group-title.<?php echo esc_html($group_id); ?> i {
+				background: url(<?php echo esc_html($group_icon); ?>) no-repeat;
 				background-size: 28px 28px;
 				background-position-y: center;
 			}
-			.payment_method_paytrail .paytrail-provider-group.selected .paytrail-provider-group-title.$group_id i {
-				background: url($group_icon) no-repeat;
+			.payment_method_paytrail .paytrail-provider-group.selected .paytrail-provider-group-title.<?php echo esc_html($group_id); ?> i {
+				background: url(<?php echo esc_html($group_icon); ?>) no-repeat;
 				background-size: 28px 28px;
 				background-position-y: center;
 			}
-EOL
-);
+			<?php
 		}
 
 	}


### PR DESCRIPTION
## Description

Item amount can't be negative on SDK level anymore. Move negative rounding to last item, that said rounding can be subtracted.
Last item could be zero amount, for example free delivery or so, campaign gift, anything, which means we cannot simply take last item.