### PR TITLE
Fix REST request validation by directly checking $_SERVER vars 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.3",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.9"
     },
     "scripts": {
         "lint": [

--- a/src/Controllers/Card.php
+++ b/src/Controllers/Card.php
@@ -69,14 +69,21 @@ class Card extends AbstractController {
 	}
 
 	private function validate_request() {
-		if (!isset($_SERVER['REQUEST_METHOD']) || 'POST' !== strtoupper($_SERVER['REQUEST_METHOD'])) {
+		if (empty($_SERVER['REQUEST_METHOD'])) {
+			throw new Exception('No request method specified');
+		}
+		
+		$request_method = filter_var($_SERVER['REQUEST_METHOD'], FILTER_SANITIZE_STRING);
+		if ('POST' !== strtoupper($request_method)) {
 			throw new Exception('Only POST requests are allowed');
 		}
-	
-		$content_type = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
-	
+		
+		$content_type = filter_var(isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '', FILTER_SANITIZE_STRING);
+		
 		if (false === stripos($content_type, 'application/json')) {
 			throw new Exception('Content-Type must be application/json');
 		}
 	}
+	
+	
 }

--- a/src/Controllers/Card.php
+++ b/src/Controllers/Card.php
@@ -69,11 +69,13 @@ class Card extends AbstractController {
 	}
 
 	private function validate_request() {
-		if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+		if (!isset($_SERVER['REQUEST_METHOD']) || 'POST' !== strtoupper($_SERVER['REQUEST_METHOD'])) {
 			throw new Exception('Only POST requests are allowed');
 		}
+	
 		$content_type = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
-		if (stripos($content_type, 'application/json') === false) {
+	
+		if (false === stripos($content_type, 'application/json')) {
 			throw new Exception('Content-Type must be application/json');
 		}
 	}

--- a/src/Controllers/Card.php
+++ b/src/Controllers/Card.php
@@ -69,14 +69,10 @@ class Card extends AbstractController {
 	}
 
 	private function validate_request() {
-		if (empty($_SERVER['REQUEST_METHOD'])) {
-			return;
-		}
-		$request = new WP_REST_Request();
-		if ( $request->get_method() != 'POST' ) {
+		if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 			throw new Exception('Only POST requests are allowed');
 		}
-		$content_type = WP_REST_Request::get_content_type();
+		$content_type = isset($_SERVER['CONTENT_TYPE']) ? $_SERVER['CONTENT_TYPE'] : '';
 		if (stripos($content_type, 'application/json') === false) {
 			throw new Exception('Content-Type must be application/json');
 		}


### PR DESCRIPTION
## Related tickets & documents

*None*

## Description

This pull request addresses a critical flaw in the `validate_request` method where it incorrectly assumed the state of a newly instantiated `WP_REST_Request` object without parameters. Originally, the method attempted to validate the request method and content type using this uninitialized object, leading to a logical mistake where the validation could never properly execute due to the absence of correctly set values within the `WP_REST_Request` object.

### Key Changes:
- Removed the creation and use of an empty `WP_REST_Request` object for method and content type checks.
- Implemented direct validation against the `$_SERVER` global for 'REQUEST_METHOD' and 'CONTENT_TYPE'.
- Simplified the method's logic, improving readability and maintainability.