### PR TITLE
Added option for users to enable Finnish bank reference number

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -745,7 +745,8 @@ final class Gateway extends \WC_Payment_Gateway {
 
 		// Store information that transaction-specific settlement was used
 		if ( $this->transaction_settlement_enable ) {
-			update_post_meta( $order_id, '_paytrail_ppa_transaction_settlement', true );
+			$order->update_meta_data( '_paytrail_ppa_transaction_settlement', true );
+			$order->save();
 		}
 
 		if (!$status && !$reference && !$refund_callback && !$refund_unique_id) {
@@ -827,7 +828,8 @@ final class Gateway extends \WC_Payment_Gateway {
 
 		// Store information that transaction-specific settlement was used
 		if ( $this->transaction_settlement_enable ) {
-			update_post_meta( $order->get_id(), '_paytrail_ppa_transaction_settlement', true );
+			$order->update_meta_data( '_paytrail_ppa_transaction_settlement', true );
+			$order->save();
 		}
 
 		if (empty($orders)) {


### PR DESCRIPTION
This can be toggled from the plugin settings page and is required when using transaction-by-transaction settlements in paytrail
