### PR TITLE
Use correct property

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -57,7 +57,7 @@ final class Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @var boolean
 	 */
-	public $testmode = false;
+	public $enable_test_mode = false;
 
 	/**
 	 * Whether the debug mode is enabled.


### PR DESCRIPTION
## Related tickets & documents

*Link to JIRA ticket if there is one.*

## Description

Fixes `Creation of dynamic property Paytrail\WooCommercePaymentGateway\Gateway::$enable_test_mode is deprecated` introduced in 02ecf5276227c9c2d154f2e8cbf29795092f4329. In PHP 8.2 and later, [setting a value to an undeclared class property is deprecated](https://php.watch/versions/8.2/dynamic-properties-deprecated
).