### PR TITLE
Add $transaction_settlement_enable property

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -70,6 +70,8 @@ final class Gateway extends \WC_Payment_Gateway {
 
 	public $callbackMode = false;
 
+	public $transaction_settlement_enable = false;
+
 	/**
 	 * Supported features.
 	 *


### PR DESCRIPTION
## Description

Fix deprecation warning.

```
Deprecated: Creation of dynamic property Paytrail\WooCommercePaymentGateway\Gateway::$transaction_settlement_enable is deprecated in paytrail-for-woocommerce/src/Gateway.php on line 180
```

Please start using PHP 8.3 for testing your code.