### PR TITLE
Add missing property

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -70,6 +70,8 @@ final class Gateway extends \WC_Payment_Gateway {
 
 	public $callbackMode = false;
 
+	public $transaction_settlement_enable = false;
+
 	/**
 	 * Supported features.
 	 *


### PR DESCRIPTION
## Related tickets & documents

*Link to JIRA ticket if there is one.*

## Description

Fixes Creation of dynamic property Paytrail\WooCommercePaymentGateway\Gateway::$transaction_settlement_enable is deprecated introduced in e39eb23f. In PHP 8.2 and later, setting a value to an undeclared class property is deprecated.