### PR TITLE
Add plugin dependency

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -5,6 +5,7 @@
  * Description: Paytrail is a payment gateway that offers 20+ payment methods for Finnish customers.
  * Version: 2.1.2
  * Requires at least: 4.9
+ * Requires Plugins: woocommerce
  * Tested up to: 6.6
  * Requires PHP: 7.3
  * WC requires at least: 3.5


### PR DESCRIPTION
## Related tickets & documents

https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/

## Description

Always require WooCommerce.
