### PR TITLE
Add default value for postalCode

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -2201,6 +2201,10 @@ final class Gateway extends \WC_Payment_Gateway {
 			$address->setCountry($this->get_option('fallback_country', ''));
 		}
 
+		if (empty($address->getPostalCode())) {
+			$address->setPostalCode('N/A');
+		}
+
 		// If we have any of the listed properties, we are good to go
 		$has_values = array_filter(
 			[ 'StreetAddress', 'PostalCode', 'City', 'County' ],


### PR DESCRIPTION
This will add default value for postal code. For example in UAE there aren't postal codes which causes error `postalCode is empty`
