### PR TITLE
Issue #226: Update inline scripts to use core api for printing script tags

### DIFF
--- a/src/View/CheckoutForm.php
+++ b/src/View/CheckoutForm.php
@@ -27,6 +27,8 @@ esc_html_e('Redirecting... If nothing happens in a few seconds, click the button
 	<p><input type="submit" value="<?php esc_html_e('Submit', 'paytrail-for-woocommerce'); ?>" /></p>
 </form>
 
-<script>
-	document.getElementById( 'checkout-redirect-form' ).submit();
-</script>
+<?php
+wp_print_inline_script_tag("
+    document.getElementById( 'checkout-redirect-form' ).submit();
+");
+?>

--- a/src/View/ProviderForm.php
+++ b/src/View/ProviderForm.php
@@ -105,10 +105,8 @@ array_walk($data['groups'], function ( $group) {
 // @todo move this where it is more suitable
 // toggle payment method group sections' visibility
 // add class to handle different theme layouts 2 or 5 items per row
-echo "
-<script>
+wp_print_inline_script_tag("
 	if (typeof initPaytrail === 'function'){
 		initPaytrail();
 	}
-</script>
-";
+");

--- a/src/View/SavedPaymentMethods.php
+++ b/src/View/SavedPaymentMethods.php
@@ -36,7 +36,8 @@ $delete_card_url = Router::get_url(Plugin::CARD_ENDPOINT, 'delete');
 	<?php esc_html_e('Add new card', 'paytrail-for-woocommerce'); ?>
 </a>
 
-<script>
+<?php ob_start(); ?>
+
 	jQuery(document).ready(function () {
 		openTokenizedCardProviderGroupSelection();
 	});
@@ -74,4 +75,5 @@ $delete_card_url = Router::get_url(Plugin::CARD_ENDPOINT, 'delete');
 			}
 		})
 	});
-</script>
+
+<?php wp_print_inline_script_tag(ob_get_clean()); ?>


### PR DESCRIPTION
## Related tickets & documents

Issue #226

## Description

Removed hardcoded script tags and instead use the official core APIs which allows plugins to filter the script attributes and e.g. inject a nonce needed to support strict CSP.

To support syntax highlighting westonrouter also gives some suggestions for different editors in https://core.trac.wordpress.org/ticket/59444.